### PR TITLE
fix(ui): fixed the landing page alignment from left to center

### DIFF
--- a/components/landing/landing-features.tsx
+++ b/components/landing/landing-features.tsx
@@ -3,7 +3,7 @@ import { BarChart3, CreditCard, DollarSign, Package, Settings, ShieldCheck } fro
 export function LandingFeatures() {
   return (
     <section id="features" className="w-full py-12 md:py-24 lg:py-32">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 mx-auto md:px-6">
         <div className="flex flex-col items-center justify-center space-y-4 text-center">
           <div className="space-y-2">
             <div className="inline-block rounded-lg bg-primary px-3 py-1 text-sm text-primary-foreground">Features</div>

--- a/components/landing/landing-footer.tsx
+++ b/components/landing/landing-footer.tsx
@@ -4,7 +4,7 @@ import { Package } from "lucide-react"
 export function LandingFooter() {
   return (
     <footer className="w-full border-t bg-background py-6 md:py-12">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 mx-auto md:px-6">
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
           <div className="space-y-4">
             <div className="flex items-center gap-2">

--- a/components/landing/landing-hero.tsx
+++ b/components/landing/landing-hero.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button"
 export function LandingHero() {
   return (
     <section className="w-full py-12 md:py-24 lg:py-32 bg-gradient-to-b from-background to-muted">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 mx-auto md:px-6">
         <div className="grid gap-6 lg:grid-cols-2 lg:gap-12 xl:grid-cols-2">
           <div className="flex flex-col justify-center space-y-4">
             <div className="space-y-2">

--- a/components/landing/landing-navbar.tsx
+++ b/components/landing/landing-navbar.tsx
@@ -25,7 +25,7 @@ export function LandingNavbar() {
         isScrolled ? "bg-background/95 backdrop-blur-sm shadow-sm" : "bg-transparent"
       }`}
     >
-      <div className="container flex h-16 items-center justify-between">
+      <div className="container flex h-16 items-center justify-between mx-auto">
         <div className="flex items-center gap-2">
           <Package className="h-6 w-6 text-primary" />
           <span className="text-lg font-bold">Product Ledger</span>

--- a/components/landing/landing-pricing.tsx
+++ b/components/landing/landing-pricing.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 export function LandingPricing() {
   return (
     <section id="pricing" className="w-full py-12 md:py-24 lg:py-32">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 mx-auto md:px-6">
         <div className="flex flex-col items-center justify-center space-y-4 text-center">
           <div className="space-y-2">
             <div className="inline-block rounded-lg bg-primary px-3 py-1 text-sm text-primary-foreground">Pricing</div>

--- a/components/landing/landing-testimonials.tsx
+++ b/components/landing/landing-testimonials.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 export function LandingTestimonials() {
   return (
     <section id="testimonials" className="w-full py-12 md:py-24 lg:py-32 bg-muted">
-      <div className="container px-4 md:px-6">
+      <div className="container px-4 mx-auto md:px-6">
         <div className="flex flex-col items-center justify-center space-y-4 text-center">
           <div className="space-y-2">
             <div className="inline-block rounded-lg bg-primary px-3 py-1 text-sm text-primary-foreground">


### PR DESCRIPTION
## Description:

**Centered the entire landing page content.** Previously, it was aligned to the left.

Fixes: #2 

## Screenshot:
### Before: 
<img width="1910" height="885" alt="image" src="https://github.com/user-attachments/assets/d502c1c0-e932-4313-8a9b-c5683474003c" />

### After:
<img width="1910" height="885" alt="image" src="https://github.com/user-attachments/assets/c6950f7a-747d-4606-85c9-4013ea711a2a" />

---

Let me know if you need any other changes! 👍

---
## EntelligenceAI PR Summary 
 This PR standardizes horizontal centering for all landing page sections by adding the 'mx-auto' class to main container divs.
- Updated container className in six landing components for improved visual alignment
- No changes to logic, structure, or functionality 

